### PR TITLE
feat: add core write operations (M1)

### DIFF
--- a/packages/cli/src/commands/done.ts
+++ b/packages/cli/src/commands/done.ts
@@ -1,0 +1,65 @@
+// src/commands/done.ts
+
+import { Command, Args, Flags } from '@oclif/core';
+import { pluginManager, renderSuccess, renderError } from '@pm-cli/core';
+import '../init.js';
+
+export default class Done extends Command {
+  static override description = 'Mark one or more tasks as done';
+
+  static override examples = [
+    '<%= config.bin %> done ASANA-123456',
+    '<%= config.bin %> done ASANA-123456 ASANA-789012',
+    '<%= config.bin %> done ASANA-123456 --json',
+  ];
+
+  static override strict = false;
+
+  static override args = {
+    ids: Args.string({
+      description: 'Task ID(s) to complete (format: PROVIDER-externalId)',
+      required: true,
+    }),
+  };
+
+  static override flags = {
+    json: Flags.boolean({
+      description: 'Output in JSON format',
+      default: false,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { argv, flags } = await this.parse(Done);
+    const taskIds = argv as string[];
+
+    if (taskIds.length === 0) {
+      renderError('Please provide at least one task ID.');
+      this.exit(1);
+      return;
+    }
+
+    await pluginManager.initialize();
+
+    const results = await pluginManager.completeTasks(taskIds);
+
+    if (flags.json) {
+      console.log(JSON.stringify(results, null, 2));
+      return;
+    }
+
+    let hasErrors = false;
+    for (const result of results) {
+      if (result.task) {
+        renderSuccess(`Completed: ${result.id} — ${result.task.title}`);
+      } else {
+        renderError(`${result.id}: ${result.error}`);
+        hasErrors = true;
+      }
+    }
+
+    if (hasErrors) {
+      this.exit(1);
+    }
+  }
+}

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -1,0 +1,58 @@
+// src/commands/open.ts
+
+import { Command, Args } from '@oclif/core';
+import { pluginManager, renderError, parseTaskId } from '@pm-cli/core';
+import '../init.js';
+
+export default class Open extends Command {
+  static override description = 'Open a task in the browser';
+
+  static override examples = [
+    '<%= config.bin %> open ASANA-123456',
+    '<%= config.bin %> open NOTION-abc123',
+  ];
+
+  static override args = {
+    id: Args.string({
+      description: 'Task ID (format: PROVIDER-externalId)',
+      required: true,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args } = await this.parse(Open);
+
+    const parsed = parseTaskId(args.id);
+    if (!parsed) {
+      renderError(`Invalid task ID format: ${args.id}`);
+      renderError('Expected format: PROVIDER-externalId (e.g., ASANA-1234567890)');
+      this.exit(1);
+      return;
+    }
+
+    await pluginManager.initialize();
+    const plugin = pluginManager.getPlugin(parsed.source);
+
+    if (!plugin) {
+      renderError(`Unknown provider: ${parsed.source}`);
+      this.exit(1);
+      return;
+    }
+
+    if (!(await plugin.isAuthenticated())) {
+      renderError(`Not connected to ${parsed.source}. Run: pm connect ${parsed.source}`);
+      this.exit(1);
+      return;
+    }
+
+    try {
+      const url = plugin.getTaskUrl(parsed.externalId);
+      const open = (await import('open')).default;
+      await open(url);
+      this.log(`Opened in browser: ${url}`);
+    } catch (error) {
+      renderError(error instanceof Error ? error.message : 'Failed to open task');
+      this.exit(1);
+    }
+  }
+}

--- a/packages/cli/src/commands/tasks/create.ts
+++ b/packages/cli/src/commands/tasks/create.ts
@@ -1,0 +1,103 @@
+// src/commands/tasks/create.ts
+
+import { Command, Args, Flags } from '@oclif/core';
+import { pluginManager, renderTask, renderSuccess, renderError } from '@pm-cli/core';
+import type { OutputFormat, ProviderType } from '@pm-cli/core';
+import '../../init.js';
+
+export default class TasksCreate extends Command {
+  static override description = 'Create a new task';
+
+  static override examples = [
+    '<%= config.bin %> tasks create "Fix login bug"',
+    '<%= config.bin %> tasks create "Update docs" --source=asana --due=2026-03-01',
+    '<%= config.bin %> tasks create "Review PR" --description="Check the auth changes" --json',
+  ];
+
+  static override args = {
+    title: Args.string({
+      description: 'Task title',
+      required: true,
+    }),
+  };
+
+  static override flags = {
+    description: Flags.string({
+      char: 'd',
+      description: 'Task description',
+    }),
+    source: Flags.string({
+      char: 's',
+      description: 'Target provider (asana, notion)',
+      options: ['asana', 'notion'],
+    }),
+    project: Flags.string({
+      char: 'p',
+      description: 'Project ID to add task to',
+    }),
+    due: Flags.string({
+      description: 'Due date (YYYY-MM-DD)',
+    }),
+    assignee: Flags.string({
+      char: 'a',
+      description: 'Assignee email',
+    }),
+    json: Flags.boolean({
+      description: 'Output in JSON format',
+      default: false,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(TasksCreate);
+    const format: OutputFormat = flags.json ? 'json' : 'table';
+
+    await pluginManager.initialize();
+
+    // Determine target provider
+    let source: ProviderType;
+    if (flags.source) {
+      source = flags.source as ProviderType;
+    } else {
+      const connected = await pluginManager.getConnectedPlugins();
+      if (connected.length === 0) {
+        renderError('No providers connected. Run: pm connect <provider>');
+        this.exit(1);
+        return;
+      }
+      if (connected.length > 1) {
+        renderError('Multiple providers connected. Use --source to specify which one.');
+        this.exit(1);
+        return;
+      }
+      source = connected[0].name;
+    }
+
+    // Parse due date if provided
+    let dueDate: Date | undefined;
+    if (flags.due) {
+      dueDate = new Date(flags.due);
+      if (isNaN(dueDate.getTime())) {
+        renderError(`Invalid date format: ${flags.due}. Use YYYY-MM-DD.`);
+        this.exit(1);
+        return;
+      }
+    }
+
+    try {
+      const task = await pluginManager.createTask(source, {
+        title: args.title,
+        description: flags.description,
+        dueDate,
+        projectId: flags.project,
+        assigneeEmail: flags.assignee,
+      });
+
+      renderSuccess(`Task created: ${task.id}`);
+      renderTask(task, format);
+    } catch (error) {
+      renderError(error instanceof Error ? error.message : 'Failed to create task');
+      this.exit(1);
+    }
+  }
+}

--- a/packages/cli/src/commands/tasks/update.ts
+++ b/packages/cli/src/commands/tasks/update.ts
@@ -1,0 +1,89 @@
+// src/commands/tasks/update.ts
+
+import { Command, Args, Flags } from '@oclif/core';
+import { pluginManager, renderTask, renderSuccess, renderError } from '@pm-cli/core';
+import type { OutputFormat, UpdateTaskInput } from '@pm-cli/core';
+import '../../init.js';
+
+export default class TasksUpdate extends Command {
+  static override description = 'Update a task';
+
+  static override examples = [
+    '<%= config.bin %> tasks update ASANA-123456 --title "New title"',
+    '<%= config.bin %> tasks update ASANA-123456 --due 2026-03-15 --status in_progress',
+    '<%= config.bin %> tasks update ASANA-123456 --description "Updated notes" --json',
+  ];
+
+  static override args = {
+    id: Args.string({
+      description: 'Task ID (format: PROVIDER-externalId)',
+      required: true,
+    }),
+  };
+
+  static override flags = {
+    title: Flags.string({
+      char: 't',
+      description: 'New task title',
+    }),
+    description: Flags.string({
+      char: 'd',
+      description: 'New task description',
+    }),
+    due: Flags.string({
+      description: 'New due date (YYYY-MM-DD, or "none" to clear)',
+    }),
+    status: Flags.string({
+      description: 'New status',
+      options: ['todo', 'in_progress', 'done'],
+    }),
+    json: Flags.boolean({
+      description: 'Output in JSON format',
+      default: false,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(TasksUpdate);
+    const format: OutputFormat = flags.json ? 'json' : 'table';
+
+    // Ensure at least one update field is provided
+    if (!flags.title && !flags.description && !flags.due && !flags.status) {
+      renderError('No updates provided. Use --title, --description, --due, or --status.');
+      this.exit(1);
+      return;
+    }
+
+    await pluginManager.initialize();
+
+    // Build updates
+    const updates: UpdateTaskInput = {};
+
+    if (flags.title) updates.title = flags.title;
+    if (flags.description) updates.description = flags.description;
+    if (flags.status) updates.status = flags.status as UpdateTaskInput['status'];
+
+    if (flags.due) {
+      if (flags.due === 'none') {
+        updates.dueDate = null;
+      } else {
+        const dueDate = new Date(flags.due);
+        if (isNaN(dueDate.getTime())) {
+          renderError(`Invalid date format: ${flags.due}. Use YYYY-MM-DD or "none".`);
+          this.exit(1);
+          return;
+        }
+        updates.dueDate = dueDate;
+      }
+    }
+
+    try {
+      const task = await pluginManager.updateTask(args.id, updates);
+      renderSuccess(`Task updated: ${task.id}`);
+      renderTask(task, format);
+    } catch (error) {
+      renderError(error instanceof Error ? error.message : 'Failed to update task');
+      this.exit(1);
+    }
+  }
+}

--- a/packages/core/src/managers/plugin-manager.ts
+++ b/packages/core/src/managers/plugin-manager.ts
@@ -1,7 +1,8 @@
 // src/managers/plugin-manager.ts
 
-import type { PMPlugin, ProviderInfo } from '../models/plugin.js';
+import type { PMPlugin, ProviderInfo, CreateTaskInput, UpdateTaskInput } from '../models/plugin.js';
 import type { Task, ProviderType } from '../models/task.js';
+import { parseTaskId } from '../models/task.js';
 
 class PluginManager {
   private plugins: Map<ProviderType, PMPlugin> = new Map();
@@ -148,6 +149,73 @@ class PluginManager {
 
     const allTasks = results.flat();
     return options?.limit ? allTasks.slice(0, options.limit) : allTasks;
+  }
+
+  /**
+   * Create a task in a specific provider
+   */
+  async createTask(
+    source: ProviderType,
+    input: CreateTaskInput
+  ): Promise<Task> {
+    const plugin = this.getPlugin(source);
+    if (!plugin) throw new Error(`Unknown provider: ${source}`);
+    if (!(await plugin.isAuthenticated())) {
+      throw new Error(`Not connected to ${source}. Run: pm connect ${source}`);
+    }
+    return plugin.createTask(input);
+  }
+
+  /**
+   * Update a task (provider determined from task ID)
+   */
+  async updateTask(
+    taskId: string,
+    updates: UpdateTaskInput
+  ): Promise<Task> {
+    const parsed = parseTaskId(taskId);
+    if (!parsed) throw new Error(`Invalid task ID format: ${taskId}`);
+
+    const plugin = this.getPlugin(parsed.source);
+    if (!plugin) throw new Error(`Unknown provider: ${parsed.source}`);
+    if (!(await plugin.isAuthenticated())) {
+      throw new Error(`Not connected to ${parsed.source}. Run: pm connect ${parsed.source}`);
+    }
+    return plugin.updateTask(parsed.externalId, updates);
+  }
+
+  /**
+   * Complete one or more tasks
+   */
+  async completeTasks(taskIds: string[]): Promise<{ id: string; task?: Task; error?: string }[]> {
+    const results: { id: string; task?: Task; error?: string }[] = [];
+
+    for (const taskId of taskIds) {
+      try {
+        const parsed = parseTaskId(taskId);
+        if (!parsed) {
+          results.push({ id: taskId, error: `Invalid task ID format: ${taskId}` });
+          continue;
+        }
+
+        const plugin = this.getPlugin(parsed.source);
+        if (!plugin) {
+          results.push({ id: taskId, error: `Unknown provider: ${parsed.source}` });
+          continue;
+        }
+        if (!(await plugin.isAuthenticated())) {
+          results.push({ id: taskId, error: `Not connected to ${parsed.source}` });
+          continue;
+        }
+
+        const task = await plugin.completeTask(parsed.externalId);
+        results.push({ id: taskId, task });
+      } catch (error) {
+        results.push({ id: taskId, error: error instanceof Error ? error.message : 'Unknown error' });
+      }
+    }
+
+    return results;
   }
 }
 

--- a/packages/core/src/models/plugin.ts
+++ b/packages/core/src/models/plugin.ts
@@ -2,6 +2,37 @@
 
 import type { Task, ProviderType } from './task.js';
 
+export interface CreateTaskInput {
+  /** Task title */
+  title: string;
+
+  /** Task description */
+  description?: string;
+
+  /** Due date */
+  dueDate?: Date;
+
+  /** Project ID to add task to */
+  projectId?: string;
+
+  /** Assignee email */
+  assigneeEmail?: string;
+}
+
+export interface UpdateTaskInput {
+  /** New title */
+  title?: string;
+
+  /** New description */
+  description?: string;
+
+  /** New due date (null to clear) */
+  dueDate?: Date | null;
+
+  /** New status */
+  status?: 'todo' | 'in_progress' | 'done';
+}
+
 export interface TaskQueryOptions {
   /** Maximum number of tasks to return */
   limit?: number;
@@ -126,6 +157,25 @@ export interface PMPlugin {
    * Get the URL to open task in browser
    */
   getTaskUrl(externalId: string): string;
+
+  // ═══════════════════════════════════════════════
+  // WRITE OPERATIONS
+  // ═══════════════════════════════════════════════
+
+  /**
+   * Create a new task
+   */
+  createTask(input: CreateTaskInput): Promise<Task>;
+
+  /**
+   * Update an existing task
+   */
+  updateTask(externalId: string, updates: UpdateTaskInput): Promise<Task>;
+
+  /**
+   * Mark a task as complete
+   */
+  completeTask(externalId: string): Promise<Task>;
 
   // ═══════════════════════════════════════════════
   // WORKSPACE OPERATIONS (optional)

--- a/packages/plugin-asana/src/asana.d.ts
+++ b/packages/plugin-asana/src/asana.d.ts
@@ -50,6 +50,8 @@ declare module 'asana' {
     getTask(taskGid: string, opts?: Record<string, unknown>): Promise<ResponseWrapper<Task>>;
     getTasksForUserTaskList(userTaskListGid: string, opts?: Record<string, unknown>): Promise<ResponseWrapper<Task[]>>;
     searchTasksForWorkspace(workspaceGid: string, opts?: Record<string, unknown>): Promise<ResponseWrapper<Task[]>>;
+    createTask(body: { data: Record<string, unknown> }, opts?: Record<string, unknown>): Promise<ResponseWrapper<Task>>;
+    updateTask(taskGid: string, body: { data: Record<string, unknown> }, opts?: Record<string, unknown>): Promise<ResponseWrapper<Task>>;
   }
 
   export class UserTaskListsApi {

--- a/packages/plugin-asana/src/client.ts
+++ b/packages/plugin-asana/src/client.ts
@@ -304,6 +304,64 @@ export class AsanaClient {
   }
 
   /**
+   * Create a new task
+   */
+  async createTask(params: {
+    name: string;
+    notes?: string;
+    due_on?: string;
+    projects?: string[];
+    assignee?: string;
+  }): Promise<AsanaTask> {
+    if (!this.tasksApi) throw new Error('Not connected');
+
+    const workspace = this.getDefaultWorkspace();
+    if (!workspace) throw new Error('No workspace found');
+
+    const data: Record<string, unknown> = {
+      name: params.name,
+      workspace: workspace.gid,
+    };
+
+    if (params.notes) data.notes = params.notes;
+    if (params.due_on) data.due_on = params.due_on;
+    if (params.projects && params.projects.length > 0) data.projects = params.projects;
+    if (params.assignee) data.assignee = params.assignee;
+
+    const response = await this.tasksApi.createTask(
+      { data },
+      { opt_fields: TASK_FIELDS.join(',') }
+    );
+    return response.data as AsanaTask;
+  }
+
+  /**
+   * Update an existing task
+   */
+  async updateTask(gid: string, params: {
+    name?: string;
+    notes?: string;
+    due_on?: string | null;
+    completed?: boolean;
+  }): Promise<AsanaTask> {
+    if (!this.tasksApi) throw new Error('Not connected');
+
+    const data: Record<string, unknown> = {};
+
+    if (params.name !== undefined) data.name = params.name;
+    if (params.notes !== undefined) data.notes = params.notes;
+    if (params.due_on !== undefined) data.due_on = params.due_on;
+    if (params.completed !== undefined) data.completed = params.completed;
+
+    const response = await this.tasksApi.updateTask(
+      gid,
+      { data },
+      { opt_fields: TASK_FIELDS.join(',') }
+    );
+    return response.data as AsanaTask;
+  }
+
+  /**
    * Get a single task by GID
    */
   async getTask(gid: string): Promise<AsanaTask | null> {


### PR DESCRIPTION
## Summary

- Add `pm tasks create <title>` — create tasks with `--description`, `--due`, `--source`, `--project`, `--assignee` flags
- Add `pm tasks update <id>` — update task title, description, due date, or status
- Add `pm done <ids...>` — quick-complete one or more tasks (variadic)
- Add `pm open <id>` — open a task in the browser

## Changes

**Core (plugin interface & manager):**
- `CreateTaskInput` and `UpdateTaskInput` types added to `PMPlugin` interface
- `createTask()`, `updateTask()`, `completeTask()` methods on `PMPlugin`
- `PluginManager` orchestration: routes writes to correct provider, handles batch completion with per-task error reporting

**Asana plugin:**
- `AsanaClient.createTask()` / `updateTask()` — calls Asana SDK
- `AsanaPlugin` implements all 3 write methods with cache invalidation
- SDK type declarations extended for `createTask` / `updateTask`

**CLI commands (4 new files):**
- `packages/cli/src/commands/tasks/create.ts`
- `packages/cli/src/commands/tasks/update.ts`
- `packages/cli/src/commands/done.ts`
- `packages/cli/src/commands/open.ts`

## Test plan

- [ ] `pm tasks create "Test task" --source=asana` creates a task and displays it
- [ ] `pm tasks update ASANA-<id> --title "Updated" --due 2026-03-01` updates the task
- [ ] `pm done ASANA-<id>` marks task complete
- [ ] `pm open ASANA-<id>` opens task URL in browser
- [ ] `pm tasks assigned --refresh` reflects changes after writes
- [ ] `pnpm build` compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)