### PR TITLE
feat: add daily driver features (M3)

### DIFF
--- a/packages/cli/src/commands/branch.ts
+++ b/packages/cli/src/commands/branch.ts
@@ -1,0 +1,93 @@
+// src/commands/branch.ts
+
+import { Command, Args, Flags } from '@oclif/core';
+import { pluginManager, parseTaskId, slugify, renderError, renderSuccess } from '@jogi47/pm-cli-core';
+import { execSync } from 'node:child_process';
+import '../init.js';
+
+export default class Branch extends Command {
+  static override description = 'Create a git branch from a task';
+
+  static override examples = [
+    '<%= config.bin %> branch ASANA-123456 --prefix feat',
+    '<%= config.bin %> branch NOTION-abc123 --prefix fix --checkout',
+    '<%= config.bin %> branch ASANA-123456 --no-id',
+  ];
+
+  static override args = {
+    id: Args.string({
+      description: 'Task ID (format: PROVIDER-externalId)',
+      required: true,
+    }),
+  };
+
+  static override flags = {
+    prefix: Flags.string({
+      char: 'p',
+      description: 'Branch prefix (feat, fix, chore)',
+      options: ['feat', 'fix', 'chore'],
+    }),
+    checkout: Flags.boolean({
+      char: 'c',
+      description: 'Also switch to the new branch',
+      default: false,
+    }),
+    'no-id': Flags.boolean({
+      description: 'Omit task ID from branch name',
+      default: false,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(Branch);
+
+    const parsed = parseTaskId(args.id);
+    if (!parsed) {
+      renderError(`Invalid task ID format: ${args.id}`);
+      renderError('Expected format: PROVIDER-externalId (e.g., ASANA-1234567890)');
+      this.exit(1);
+      return;
+    }
+
+    await pluginManager.initialize();
+    const plugin = pluginManager.getPlugin(parsed.source);
+
+    if (!plugin) {
+      renderError(`Unknown provider: ${parsed.source}`);
+      this.exit(1);
+      return;
+    }
+
+    if (!(await plugin.isAuthenticated())) {
+      renderError(`Not connected to ${parsed.source}. Run: pm connect ${parsed.source}`);
+      this.exit(1);
+      return;
+    }
+
+    try {
+      const task = await plugin.getTask(parsed.externalId);
+      if (!task) {
+        renderError(`Task not found: ${args.id}`);
+        this.exit(1);
+        return;
+      }
+
+      const slug = slugify(task.title);
+      let branchName = flags['no-id'] ? slug : `${args.id.toLowerCase()}-${slug}`;
+      if (flags.prefix) {
+        branchName = `${flags.prefix}/${branchName}`;
+      }
+
+      execSync(`git branch ${branchName}`, { stdio: 'pipe' });
+      renderSuccess(`Created branch: ${branchName}`);
+
+      if (flags.checkout) {
+        execSync(`git checkout ${branchName}`, { stdio: 'pipe' });
+        renderSuccess(`Switched to branch: ${branchName}`);
+      }
+    } catch (error) {
+      renderError(error instanceof Error ? error.message : 'Failed to create branch');
+      this.exit(1);
+    }
+  }
+}

--- a/packages/cli/src/commands/comment.ts
+++ b/packages/cli/src/commands/comment.ts
@@ -1,0 +1,39 @@
+// src/commands/comment.ts
+
+import { Command, Args } from '@oclif/core';
+import { pluginManager, renderError, renderSuccess } from '@jogi47/pm-cli-core';
+import '../init.js';
+
+export default class Comment extends Command {
+  static override description = 'Add a comment to a task';
+
+  static override examples = [
+    '<%= config.bin %> comment ASANA-123456 "Fixed in commit abc"',
+    '<%= config.bin %> comment NOTION-abc123 "Needs review"',
+  ];
+
+  static override args = {
+    id: Args.string({
+      description: 'Task ID (format: PROVIDER-externalId)',
+      required: true,
+    }),
+    message: Args.string({
+      description: 'Comment text',
+      required: true,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args } = await this.parse(Comment);
+
+    await pluginManager.initialize();
+
+    try {
+      await pluginManager.addComment(args.id, args.message);
+      renderSuccess(`Comment added to ${args.id}`);
+    } catch (error) {
+      renderError(error instanceof Error ? error.message : 'Failed to add comment');
+      this.exit(1);
+    }
+  }
+}

--- a/packages/cli/src/commands/summary.ts
+++ b/packages/cli/src/commands/summary.ts
@@ -1,0 +1,64 @@
+// src/commands/summary.ts
+
+import { Command, Flags } from '@oclif/core';
+import { pluginManager, renderSummary, renderError } from '@jogi47/pm-cli-core';
+import type { OutputFormat, Task } from '@jogi47/pm-cli-core';
+import '../init.js';
+
+export default class Summary extends Command {
+  static override description = 'Show provider connection status and task count statistics';
+
+  static override examples = [
+    '<%= config.bin %> summary',
+    '<%= config.bin %> summary --json',
+  ];
+
+  static override flags = {
+    json: Flags.boolean({
+      description: 'Output in JSON format',
+      default: false,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(Summary);
+    const format: OutputFormat = flags.json ? 'json' : 'table';
+
+    await pluginManager.initialize();
+
+    try {
+      const providers = await pluginManager.getProvidersInfo();
+
+      let tasks: Task[];
+      try {
+        tasks = await pluginManager.aggregateTasks('assigned');
+      } catch {
+        tasks = [];
+      }
+
+      const now = new Date();
+      const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
+      let overdue = 0;
+      let dueToday = 0;
+      let inProgress = 0;
+      let total = 0;
+
+      for (const task of tasks) {
+        if (task.status === 'done') continue;
+        total++;
+        if (task.status === 'in_progress') inProgress++;
+        if (task.dueDate) {
+          const taskDate = new Date(task.dueDate.getFullYear(), task.dueDate.getMonth(), task.dueDate.getDate());
+          if (taskDate.getTime() < today.getTime()) overdue++;
+          else if (taskDate.getTime() === today.getTime()) dueToday++;
+        }
+      }
+
+      renderSummary(providers, { overdue, dueToday, inProgress, total }, format);
+    } catch (error) {
+      renderError(error instanceof Error ? error.message : 'Failed to fetch summary');
+      this.exit(1);
+    }
+  }
+}

--- a/packages/cli/src/commands/tasks/overdue.ts
+++ b/packages/cli/src/commands/tasks/overdue.ts
@@ -1,8 +1,8 @@
 // src/commands/tasks/overdue.ts
 
 import { Command, Flags } from '@oclif/core';
-import { pluginManager, renderTasks, renderError } from '@jogi47/pm-cli-core';
-import type { OutputFormat, ProviderType } from '@jogi47/pm-cli-core';
+import { pluginManager, renderTasks, renderTasksPlain, renderTaskIds, renderError, filterAndSortTasks } from '@jogi47/pm-cli-core';
+import type { OutputFormat, ProviderType, TaskStatus, FilterSortOptions } from '@jogi47/pm-cli-core';
 import '../../init.js';
 
 export default class TasksOverdue extends Command {
@@ -12,6 +12,8 @@ export default class TasksOverdue extends Command {
     '<%= config.bin %> tasks overdue',
     '<%= config.bin %> tasks overdue --source=asana',
     '<%= config.bin %> tasks overdue --json',
+    '<%= config.bin %> tasks overdue --sort=priority',
+    '<%= config.bin %> tasks overdue --plain',
   ];
 
   static override flags = {
@@ -34,6 +36,25 @@ export default class TasksOverdue extends Command {
       description: 'Bypass cache and fetch fresh data',
       default: false,
     }),
+    status: Flags.string({
+      description: 'Filter by status (todo, in_progress, done)',
+      options: ['todo', 'in_progress', 'done'],
+    }),
+    priority: Flags.string({
+      description: 'Filter by priority (comma-separated: low,medium,high,urgent)',
+    }),
+    sort: Flags.string({
+      description: 'Sort by field (due, priority, status, source, title)',
+      options: ['due', 'priority', 'status', 'source', 'title'],
+    }),
+    plain: Flags.boolean({
+      description: 'Tab-separated output, no colors or borders',
+      default: false,
+    }),
+    'ids-only': Flags.boolean({
+      description: 'Output just task IDs, one per line',
+      default: false,
+    }),
   };
 
   async run(): Promise<void> {
@@ -43,13 +64,27 @@ export default class TasksOverdue extends Command {
     await pluginManager.initialize();
 
     try {
-      const tasks = await pluginManager.aggregateTasks('overdue', {
+      let tasks = await pluginManager.aggregateTasks('overdue', {
         source: flags.source as ProviderType | undefined,
         limit: flags.limit,
         refresh: flags.refresh,
       });
 
-      renderTasks(tasks, format);
+      const filterOpts: FilterSortOptions = {};
+      if (flags.status) filterOpts.status = flags.status as TaskStatus;
+      if (flags.priority) filterOpts.priority = flags.priority.split(',');
+      if (flags.sort) filterOpts.sort = flags.sort as FilterSortOptions['sort'];
+      if (filterOpts.status || filterOpts.priority || filterOpts.sort) {
+        tasks = filterAndSortTasks(tasks, filterOpts);
+      }
+
+      if (flags['ids-only']) {
+        renderTaskIds(tasks);
+      } else if (flags.plain) {
+        renderTasksPlain(tasks);
+      } else {
+        renderTasks(tasks, format);
+      }
     } catch (error) {
       renderError(error instanceof Error ? error.message : 'Failed to fetch tasks');
       this.exit(1);

--- a/packages/core/src/models/plugin.ts
+++ b/packages/core/src/models/plugin.ts
@@ -177,6 +177,11 @@ export interface PMPlugin {
    */
   completeTask(externalId: string): Promise<Task>;
 
+  /**
+   * Add a comment to a task
+   */
+  addComment?(externalId: string, body: string): Promise<void>;
+
   // ═══════════════════════════════════════════════
   // WORKSPACE OPERATIONS (optional)
   // ═══════════════════════════════════════════════

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './date.js';
 export * from './errors.js';
 export * from './output.js';
+export * from './string.js';

--- a/packages/core/src/utils/string.ts
+++ b/packages/core/src/utils/string.ts
@@ -1,0 +1,12 @@
+/**
+ * Convert a string to a URL/branch-friendly slug
+ */
+export function slugify(str: string): string {
+  return str
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/[\s]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 50);
+}

--- a/packages/plugin-asana/src/asana.d.ts
+++ b/packages/plugin-asana/src/asana.d.ts
@@ -54,6 +54,10 @@ declare module 'asana' {
     updateTask(taskGid: string, body: { data: Record<string, unknown> }, opts?: Record<string, unknown>): Promise<ResponseWrapper<Task>>;
   }
 
+  export class StoriesApi {
+    createStoryForTask(taskGid: string, body: { data: Record<string, unknown> }, opts?: Record<string, unknown>): Promise<ResponseWrapper<unknown>>;
+  }
+
   export class UserTaskListsApi {
     getUserTaskListForUser(userGid: string, workspaceGid: string, opts?: Record<string, unknown>): Promise<ResponseWrapper<UserTaskList>>;
   }

--- a/packages/plugin-asana/src/client.ts
+++ b/packages/plugin-asana/src/client.ts
@@ -65,6 +65,7 @@ export class AsanaClient {
   private usersApi: Asana.UsersApi | null = null;
   private tasksApi: Asana.TasksApi | null = null;
   private userTaskListsApi: Asana.UserTaskListsApi | null = null;
+  private storiesApi: Asana.StoriesApi | null = null;
   private currentUser: AsanaUser | null = null;
   private workspaces: AsanaWorkspace[] = [];
   private selectedWorkspaceGid: string | null = null;
@@ -100,6 +101,7 @@ export class AsanaClient {
     this.usersApi = new Asana.UsersApi();
     this.tasksApi = new Asana.TasksApi();
     this.userTaskListsApi = new Asana.UserTaskListsApi();
+    this.storiesApi = new Asana.StoriesApi();
   }
 
   /**
@@ -130,6 +132,7 @@ export class AsanaClient {
     this.usersApi = null;
     this.tasksApi = null;
     this.userTaskListsApi = null;
+    this.storiesApi = null;
     this.currentUser = null;
     this.workspaces = [];
     this.selectedWorkspaceGid = null;
@@ -375,6 +378,16 @@ export class AsanaClient {
     } catch {
       return null;
     }
+  }
+  /**
+   * Add a comment (story) to a task
+   */
+  async addComment(taskGid: string, text: string): Promise<void> {
+    if (!this.storiesApi) throw new Error('Not connected');
+
+    await this.storiesApi.createStoryForTask(taskGid, {
+      data: { text },
+    });
   }
 }
 

--- a/packages/plugin-asana/src/index.ts
+++ b/packages/plugin-asana/src/index.ts
@@ -168,6 +168,10 @@ export class AsanaPlugin implements PMPlugin {
     return task;
   }
 
+  async addComment(externalId: string, body: string): Promise<void> {
+    await asanaClient.addComment(externalId, body);
+  }
+
   // ═══════════════════════════════════════════════
   // WORKSPACE OPERATIONS
   // ═══════════════════════════════════════════════

--- a/packages/plugin-notion/src/client.ts
+++ b/packages/plugin-notion/src/client.ts
@@ -240,6 +240,25 @@ export class NotionClient {
 
     return schema;
   }
+  /**
+   * Add a comment by appending a paragraph block to a page
+   */
+  async addComment(pageId: string, text: string): Promise<void> {
+    if (!this.client) throw new Error('Not connected');
+
+    await this.client.blocks.children.append({
+      block_id: pageId,
+      children: [
+        {
+          object: 'block' as const,
+          type: 'paragraph' as const,
+          paragraph: {
+            rich_text: [{ type: 'text' as const, text: { content: text } }],
+          },
+        },
+      ],
+    });
+  }
 }
 
 // Export singleton

--- a/packages/plugin-notion/src/index.ts
+++ b/packages/plugin-notion/src/index.ts
@@ -280,6 +280,10 @@ export class NotionPlugin implements PMPlugin {
   async completeTask(externalId: string): Promise<Task> {
     return this.updateTask(externalId, { status: 'done' });
   }
+
+  async addComment(externalId: string, body: string): Promise<void> {
+    await notionClient.addComment(externalId, body);
+  }
 }
 
 // ═══════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- **`pm today`** — Morning dashboard grouping tasks by overdue (red), due today (yellow), and in-progress
- **`pm summary`** — Provider connection status + task count statistics (overdue, due today, in-progress, total open)
- **`pm branch <id>`** — Create a git branch from a task title with `--prefix` (feat/fix/chore), `--checkout`, and `--no-id` flags
- **`pm comment <id> <message>`** — Add a comment to a task (Asana stories API / Notion block append)
- **Filtering & sorting** on `tasks assigned`, `tasks overdue`, `tasks search` — new `--status`, `--priority`, `--sort` flags
- **Piping support** — `--plain` (tab-separated, no ANSI) and `--ids-only` (one ID per line) on all list commands
- Core utilities: `slugify()`, `filterAndSortTasks()`, `addComment` on plugin interface + both providers

## Test plan
- [ ] `pnpm build` — all packages compile cleanly
- [ ] `pm today` — shows grouped dashboard
- [ ] `pm summary` — shows provider status + task counts
- [ ] `pm tasks assigned --status=todo` — filters by status
- [ ] `pm tasks assigned --sort=priority` — sorts by priority
- [ ] `pm tasks assigned --plain` — tab-separated output
- [ ] `pm tasks assigned --ids-only` — one ID per line
- [ ] `pm branch ASANA-123 --prefix feat --checkout` — creates and switches to branch
- [ ] `pm comment ASANA-123 "Fixed in commit abc"` — adds comment to task

🤖 Generated with [Claude Code](https://claude.com/claude-code)